### PR TITLE
Fix various bubble menu inconsistencies

### DIFF
--- a/src/OnScreen/BackgroundWindow.vala
+++ b/src/OnScreen/BackgroundWindow.vala
@@ -118,7 +118,7 @@ namespace Komorebi.OnScreen {
 				videoPlayback.set_seek_flags (ClutterGst.SeekFlags.ACCURATE);
 
 				videoContent.player = videoPlayback;
-        if (mutePlayback) {
+				if (mutePlayback) {
 					muteVolume();
 				}
 				videoPlayback.notify["progress"].connect(() => {
@@ -208,7 +208,7 @@ namespace Komorebi.OnScreen {
 					if(bubbleMenu.opacity > 0)
 						return false;
 
-					if(desktopIcons != null)
+					if(desktopIcons != null && showDesktopIcons)
 						if(e.x >= desktopIcons.x && e.x <= (desktopIcons.x + desktopIcons.width) && 
 							e.y >= desktopIcons.y && e.y <= (desktopIcons.y + desktopIcons.height))
 							return false;

--- a/src/OnScreen/BubbleMenu.vala
+++ b/src/OnScreen/BubbleMenu.vala
@@ -82,6 +82,19 @@ namespace Komorebi.OnScreen {
 			makeAliasMenuItem = new BubbleMenuItem("Make Alias");
 			getInfoMenuItem = new BubbleMenuItem("Get Info");
 
+			add_child(moveToTrashMenuItem);
+			add_child(copyMenuItem);
+			// add_child(makeAliasMenuItem);
+			add_child(getInfoMenuItem);
+			add_child(newFolderMenuItem);
+			add_child(pasteMenuItem);
+			add_child(refreshMenuItem);
+			add_child(changeWallpaperMenuItem);
+			add_child(preferencesMenuItem);
+
+			foreach(Clutter.Actor child in get_children())
+				child.visible = false;
+
 			// Signals
 			signalsSetup();
 		}
@@ -187,10 +200,9 @@ namespace Komorebi.OnScreen {
 
 			if(menuType == MenuType.ICON) {
 
-				add_child(moveToTrashMenuItem);
-				add_child(copyMenuItem);
-				// add_child(makeAliasMenuItem);
-				add_child(getInfoMenuItem);
+				moveToTrashMenuItem.visible = true;
+				copyMenuItem.visible = true;
+				getInfoMenuItem.visible = true;
 
 			} else {
 
@@ -212,28 +224,22 @@ namespace Komorebi.OnScreen {
 
 				// Hide 'New Folder' and 'Paste' item if we're not showing icons
 				if(showDesktopIcons) {
-					add_child(newFolderMenuItem);
-					add_child(pasteMenuItem);
+					newFolderMenuItem.visible = true;
+					pasteMenuItem.visible = true;
 				}
 
 				// If we have a web page wallpaper, show the 'refresh wallpaper' menu item
 				if(wallpaperType == "web_page")
-					add_child(refreshMenuItem);
+					refreshMenuItem.visible = true;
 
-				add_child(changeWallpaperMenuItem);
-				add_child(preferencesMenuItem);
+				changeWallpaperMenuItem.visible = true;
+				preferencesMenuItem.visible = true;
 
 			}
 
 			// Make sure we don't display off the screen
-			if(x + 15 < 0) {
-				x = 0;
-			} else if (x >= screenWidth - width) {
-				x -= width + 15;
-			}
-
-			if((y + height) >= parent.mainActor.height)
-				y -= (height + 10);
+			x = double.min(x, screenWidth - (width + 15 * 2));
+			y = double.min(y, parent.mainActor.height - (height + 15 * 2));
 
 			opacity = 0;
 			this.x = (float)x;
@@ -258,7 +264,8 @@ namespace Komorebi.OnScreen {
 			set_easing_mode (Clutter.AnimationMode.EASE_IN_SINE);
 			restore_easing_state ();
 
-			remove_all_children();
+			foreach(Clutter.Actor child in get_children())
+				child.visible = false;
 
 			// Undim all icon
 			foreach (var icon in parent.desktopIcons.iconsList)


### PR DESCRIPTION
Fixes various issues from the *right-click* bubble menu:

- The menu was still considering the position of desktop icons even when disabled, which is likely the issue many users had when they said *"right clicking was fiddly or not working"*. This was fixed: right-click is now working everywhere when icons are disabled.
- The safeguard to prevent this menu from going off-screen only worked the first time, because the way it was designed, it removed/added children when showing/disappearing, resetting the width/height to 0. Changed to a **much** better way of doing it, and problem is now solved.
- Fix slight margin problem. Menu now has a proper 15px margin on all four directions *(before it only had for left and up directions)*.