### PR TITLE
komorebi: FHS compliant install locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,19 +81,17 @@ add_executable(komorebi-wallpaper-creator ${WALLPAPER_CREATOR})
 target_link_libraries(komorebi ${DEPS_LIBRARIES} -lm)
 target_link_libraries(komorebi-wallpaper-creator ${DEPS_LIBRARIES} -lm)
 
-install(TARGETS komorebi RUNTIME DESTINATION /System/Applications/)
-install(TARGETS komorebi-wallpaper-creator RUNTIME DESTINATION /System/Applications/)
-
+install(TARGETS komorebi RUNTIME DESTINATION /usr/bin/)
+install(TARGETS komorebi-wallpaper-creator RUNTIME DESTINATION /usr/bin/)
 
 ######### Wallpapers ############
-install(DIRECTORY data/Wallpapers/ DESTINATION /System/Resources/Komorebi)
-
+install(DIRECTORY data/Wallpapers/ DESTINATION /usr/share/komorebi/)
 
 ######### Fonts ############
-install(DIRECTORY data/Fonts/ DESTINATION /usr/share/fonts)
+install(DIRECTORY data/Fonts/ DESTINATION /usr/share/fonts/)
 
 ######### Icons ############
-install(DIRECTORY data/Icons/ DESTINATION /System/Resources/Komorebi)
+install(DIRECTORY data/Icons/ DESTINATION /usr/share/pixmaps/komorebi/)
 
 ######### Other ############
 install(FILES data/Other/komorebi.desktop DESTINATION /usr/share/applications/)

--- a/data/Other/komorebi.desktop
+++ b/data/Other/komorebi.desktop
@@ -2,8 +2,8 @@
 Name=Komorebi
 Comment=An awesome wallpapers manager
 Keywords=wallpaper;settings; preferences;
-Icon=/System/Resources/Komorebi/komorebi.svg
-Exec=/System/Applications/komorebi
+Icon=/usr/share/pixmaps/komorebi/komorebi.svg
+Exec=/usr/bin/komorebi
 Terminal=false
 Type=Application
 StartupNotify=true

--- a/data/Other/postinst
+++ b/data/Other/postinst
@@ -18,7 +18,7 @@ done
 
 echo "[INFO]: Updating existing Komorebi Wallpapers.."
 
-wallpapers=$(ls -d -1 /System/Resources/Komorebi/*/)
+wallpapers=$(ls -d -1 /usr/share/komorebi/*/)
 
 for wallpaper in $wallpapers; do
 

--- a/data/Other/wallpapercreator.desktop
+++ b/data/Other/wallpapercreator.desktop
@@ -2,8 +2,8 @@
 Name=Wallpaper Creator
 Comment=Create wallpapers for Komorebi
 Keywords=wallpaper; settings; preferences;
-Icon=/System/Resources/Komorebi/wallpaper_creator.svg
-Exec=/System/Applications/komorebi-wallpaper-creator
+Icon=/usr/share/pixmaps/komorebi/wallpaper_creator.svg
+Exec=/usr/bin/komorebi-wallpaper-creator
 Terminal=false
 Type=Application
 StartupNotify=true

--- a/extra/wallpaper-creator/OnScreen/FinalPage.vala
+++ b/extra/wallpaper-creator/OnScreen/FinalPage.vala
@@ -21,7 +21,7 @@ namespace WallpaperCreator.OnScreen {
 
     public class FinalPage : Box {
 
-        Image logo = new Image.from_file("/System/Resources/Komorebi/done.svg");
+        Image logo = new Image.from_file("/usr/share/pixmaps/komorebi/done.svg");
 
         Label titleLabel = new Label("");
         Label descLabel = new Label("");
@@ -46,7 +46,7 @@ namespace WallpaperCreator.OnScreen {
 
             titleLabel.set_markup("<span font='Lato 20'>Done</span>");
 
-            var mv_command = @"sudo mv $(Environment.get_home_dir())/$(wallpaperName.replace(" ", "_").replace(".", "_").down()) /System/Resources/Komorebi";
+            var mv_command = @"sudo mv $(Environment.get_home_dir())/$(wallpaperName.replace(" ", "_").replace(".", "_").down()) /usr/share/komorebi";
 
             descLabel.set_markup(@"<span font='Lato Light 12'>Open 'Terminal' then paste the following:\n<b>$mv_command</b>\nOnce done, you can change the wallpaper in <i>'Change Wallpaper'</i>.</span>");
 

--- a/extra/wallpaper-creator/OnScreen/InitialPage.vala
+++ b/extra/wallpaper-creator/OnScreen/InitialPage.vala
@@ -39,7 +39,7 @@ namespace WallpaperCreator.OnScreen {
 
         Label chooseFileLabel = new Label("Where is the image located?");
         Box locationBox = new Box(Orientation.HORIZONTAL, 10);
-        Entry locationEntry = new Entry() { placeholder_text = "/Users/cheesecakeufo/my_picture.jpg" };
+        Entry locationEntry = new Entry() { placeholder_text = "~/Pictures/my_picture.jpg" };
         FileChooserButton chooseFileButton = new FileChooserButton("Choose File", Gtk.FileChooserAction.OPEN);
 
         Revealer revealer = new Revealer();
@@ -160,7 +160,7 @@ namespace WallpaperCreator.OnScreen {
             titleBox.add(titleLabel);
             titleBox.add(aboutLabel);
 
-            aboutGrid.attach(new Image.from_file("/System/Resources/Komorebi/wallpaper_creator.svg"), 0, 0, 1, 1);
+            aboutGrid.attach(new Image.from_file("/usr/share/pixmaps/komorebi/wallpaper_creator.svg"), 0, 0, 1, 1);
             aboutGrid.attach(titleBox, 1, 0, 1, 1);
 
             thumbnailBox.add(chooseThumbnailLabel);

--- a/extra/wallpaper-creator/OnScreen/NewWallpaperWindow.vala
+++ b/extra/wallpaper-creator/OnScreen/NewWallpaperWindow.vala
@@ -158,7 +158,7 @@ namespace WallpaperCreator.OnScreen {
 
 					} else {
 						addLayerButton.visible = false;
-						optionsPage.setImage("/System/Resources/Komorebi/blank.svg");
+						optionsPage.setImage("/usr/share/pixmaps/komorebi/blank.svg");
 					}
 
 					stack.add_named(optionsPage, "options");

--- a/src/OnScreen/AssetActor.vala
+++ b/src/OnScreen/AssetActor.vala
@@ -54,7 +54,7 @@ namespace Komorebi.OnScreen {
             if(assetHeight <= 0)
                 assetHeight = screenHeight;
 
-            var assetPath = @"/System/Resources/Komorebi/$wallpaperName/assets.png";
+            var assetPath = @"/usr/share/komorebi/$wallpaperName/assets.png";
 
             // make sure the asset exists
             if(!File.new_for_path(assetPath).query_exists()) {

--- a/src/OnScreen/BackgroundWindow.vala
+++ b/src/OnScreen/BackgroundWindow.vala
@@ -349,7 +349,7 @@ namespace Komorebi.OnScreen {
 				
 				if(wallpaperType == "video") {
 
-					var videoPath = @"file:///System/Resources/Komorebi/$wallpaperName/$videoFileName";
+					var videoPath = @"file:///usr/share/komorebi/$wallpaperName/$videoFileName";
 					videoPlayback.uri = videoPath;
 					videoPlayback.playing = true;
 
@@ -385,7 +385,7 @@ namespace Komorebi.OnScreen {
 
 			wallpaperActor.set_content(wallpaperImage);
 
-			wallpaperPixbuf = new Gdk.Pixbuf.from_file_at_scale(@"/System/Resources/Komorebi/$wallpaperName/wallpaper.jpg",
+			wallpaperPixbuf = new Gdk.Pixbuf.from_file_at_scale(@"/usr/share/komorebi/$wallpaperName/wallpaper.jpg",
 																scaleWidth, scaleHeight, false);
 
 			wallpaperImage.set_data (wallpaperPixbuf.get_pixels(), Cogl.PixelFormat.RGB_888,

--- a/src/OnScreen/InfoWindow.vala
+++ b/src/OnScreen/InfoWindow.vala
@@ -122,7 +122,7 @@ namespace Komorebi.OnScreen {
             });
 
     		// Add widgets
-            closeButton.add(new Image.from_file("/System/Resources/Komorebi/close_btn.svg"));
+            closeButton.add(new Image.from_file("/usr/share/pixmaps/komorebi/close_btn.svg"));
     		headerBar.pack_start(closeButton, false, false);
 
     		topBox.add(titleLabel);

--- a/src/OnScreen/PreferencesWindow.vala
+++ b/src/OnScreen/PreferencesWindow.vala
@@ -270,7 +270,7 @@ namespace Komorebi.OnScreen {
 			titleBox.add(titleLabel);
 			titleBox.add(aboutLabel);
 
-			aboutGrid.attach(new Image.from_file("/System/Resources/Komorebi/komorebi.svg"), 0, 0, 1, 1);
+			aboutGrid.attach(new Image.from_file("/usr/share/pixmaps/komorebi/komorebi.svg"), 0, 0, 1, 1);
 			aboutGrid.attach(titleBox, 1, 0, 1, 1);
 
 			bottomPreferencesBox.pack_start(donateButton);
@@ -284,7 +284,7 @@ namespace Komorebi.OnScreen {
 			preferencesPage.add(pausePlaybackButton);
 			preferencesPage.pack_end(bottomPreferencesBox);
 
-			bottomWallpapersBox.add(new Image.from_file("/System/Resources/Komorebi/info.svg"));
+			bottomWallpapersBox.add(new Image.from_file("/usr/share/pixmaps/komorebi/info.svg"));
 			bottomWallpapersBox.add(currentWallpaperLabel);
 
 			if(!canPlayVideos()) {

--- a/src/OnScreen/Thumbnail.vala
+++ b/src/OnScreen/Thumbnail.vala
@@ -25,7 +25,7 @@ namespace Komorebi.OnScreen {
 
 		Overlay overlay = new Overlay();
 		Image thumbnailImage = new Image();
-		Image borderImage = new Image.from_file("/System/Resources/Komorebi/thumbnail_border.svg");
+		Image borderImage = new Image.from_file("/usr/share/pixmaps/komorebi/thumbnail_border.svg");
 		Revealer revealer = new Revealer();
 
 		// Signaled when clicked
@@ -80,7 +80,7 @@ namespace Komorebi.OnScreen {
 
 		public Thumbnail.Add() {
 
-			thumbnailImage.pixbuf = new Gdk.Pixbuf.from_file_at_scale("/System/Resources/Komorebi/thumbnail_add.svg", 150, 100, false);
+			thumbnailImage.pixbuf = new Gdk.Pixbuf.from_file_at_scale("/usr/share/pixmaps/komorebi/thumbnail_add.svg", 150, 100, false);
 
 		}
 

--- a/src/OnScreen/WallpapersSelector.vala
+++ b/src/OnScreen/WallpapersSelector.vala
@@ -24,7 +24,7 @@ namespace Komorebi.OnScreen {
 
 	public class WallpapersSelector : ScrolledWindow {
 
-		public string path = "/System/Resources/Komorebi/";
+		public string path = "/usr/share/komorebi/";
 
 		Gtk.Grid grid = new Grid();
 
@@ -68,7 +68,7 @@ namespace Komorebi.OnScreen {
 			foreach(var thumbnail in thumbnailsList)
 				thumbnailsList.remove(thumbnail);
 
-			File wallpapersFolder = File.new_for_path("/System/Resources/Komorebi");
+			File wallpapersFolder = File.new_for_path("/usr/share/komorebi");
 
 			try {
 
@@ -98,7 +98,7 @@ namespace Komorebi.OnScreen {
 					}
 
 			} catch {
-				print("Could not read directory '/System/Resources/Komorebi/'");
+				print("Could not read directory '/usr/share/komorebi/'");
 			}
 		}
 

--- a/src/Utilities.vala
+++ b/src/Utilities.vala
@@ -266,14 +266,14 @@ namespace Komorebi.Utilities {
 
 		// check if the wallpaper exists
 		// also, make sure the wallpaper name is valid
-		var wallpaperPath = @"/System/Resources/Komorebi/$wallpaperName";
+		var wallpaperPath = @"/usr/share/komorebi/$wallpaperName";
 		var wallpaperConfigPath = @"$wallpaperPath/config";
 
 		if(wallpaperName == null || !File.new_for_path(wallpaperPath).query_exists() ||
 			!File.new_for_path(wallpaperConfigPath).query_exists()) {
 
 			wallpaperName = "foggy_sunny_mountain";
-			wallpaperPath = @"/System/Resources/Komorebi/$wallpaperName";
+			wallpaperPath = @"/usr/share/komorebi/$wallpaperName";
 			wallpaperConfigPath = @"$wallpaperPath/config";
 
 			print(@"[ERROR]: got an invalid wallpaper. Setting to default: $wallpaperName\n");
@@ -342,7 +342,7 @@ namespace Komorebi.Utilities {
 		assetHeight = wallpaperKeyFile.get_integer ("Asset", "Height");
 
 		// Set GNOME's wallpaper to this
-		var wallpaperJpgPath = @"/System/Resources/Komorebi/$wallpaperName/wallpaper.jpg";
+		var wallpaperJpgPath = @"/usr/share/komorebi/$wallpaperName/wallpaper.jpg";
 		new GLib.Settings("org.gnome.desktop.background").set_string("picture-uri", ("file://" + wallpaperJpgPath));
 		new GLib.Settings("org.gnome.desktop.background").set_string("picture-options", "stretched");
 	}


### PR DESCRIPTION
/System/Applications --> /usr/bin
/System/Resources --> /usr/share
/Komorebi --> komorebi

Icons now installed to /usr/share/pixmaps/komorebi/

Trailing slashes added to CMakeLists.txt for consistency in paths.

The postinst script will need to be looked at by someone that uses a debian-based system.