### PR TITLE
Improve wayland detection

### DIFF
--- a/src/Main.vala
+++ b/src/Main.vala
@@ -26,7 +26,8 @@ namespace Komorebi {
 
         // We're not supporting Wayland at the moment
         // due to some restrictions
-        if(Environment.get_variable ("XDG_SESSION_DESKTOP").contains("wayland")) {
+        if(Environment.get_variable ("XDG_SESSION_TYPE").contains("wayland") ||
+            Environment.get_variable ("WAYLAND_DISPLAY").length > 0) {
             return false;
         }
 


### PR DESCRIPTION
Some users are having problems because Komorebi launches on a Wayland environment. The detection method was wrong: [XDG_SESSION_DESKTOP](https://www.freedesktop.org/software/systemd/man/pam_systemd.html#%24XDG_SESSION_DESKTOP) indicates the current desktop environment, not the window system.

Changed it to use XDG_SESSION_TYPE, and to also see if WAYLAND_DISPLAY is set.