### PR TITLE
Fix crash when detecting Wayland systems

### DIFF
--- a/src/Main.vala
+++ b/src/Main.vala
@@ -27,7 +27,7 @@ namespace Komorebi {
         // We're not supporting Wayland at the moment
         // due to some restrictions
         if(Environment.get_variable ("XDG_SESSION_TYPE").contains("wayland") ||
-            Environment.get_variable ("WAYLAND_DISPLAY").length > 0) {
+            Environment.get_variable ("WAYLAND_DISPLAY") != null) {
             return false;
         }
 


### PR DESCRIPTION
Apparently, a non-set environment variable is actually `null`. I assumed it was an empty string `""`. This fixes the crash that happens because of trying to see the length of something `null`.