### PR TITLE
Added option --single-screen argument

### DIFF
--- a/src/Main.vala
+++ b/src/Main.vala
@@ -38,7 +38,7 @@ namespace Komorebi {
 
         print("Welcome to Komorebi\n");
 
-        if(args[1] == "--version" || args[1] == "version") {
+        if(hasArg("--version", args) || hasArg("version", args)) {
             print("Version: 2.1 - Summit\nCreated by: Abraham Masri @cheesecakeufo\n\n");
             return;
         }
@@ -63,7 +63,7 @@ namespace Komorebi {
         Gtk.Settings.get_default().gtk_application_prefer_dark_theme = true;
 
         var screen = Gdk.Screen.get_default ();
-        int monitorCount = screen.get_n_monitors();
+        int monitorCount = hasArg("--single-screen", args) ? 1 : screen.get_n_monitors();
 
 
         initializeClipboard(screen);

--- a/src/Utilities.vala
+++ b/src/Utilities.vala
@@ -389,4 +389,14 @@ namespace Komorebi.Utilities {
 
 		return false;
 	}
+
+	/* A quick way to find a given arg from the args list */
+	public bool hasArg(string arg, string[] args) {
+		foreach(string s in args) {
+			if(s == arg)
+				return true;
+		}
+
+		return false;
+	}
 }


### PR DESCRIPTION
A lot of users are experiencing X/GDK crashes which are linked to having [multi-monitor setups](https://github.com/cheesecakeufo/komorebi/issues/126). This PR introduces an optional `--single-screen` argument to force komorebi to run only on the main screen. We need to find a proper fix, but until then, this should help people getting komorebi to at least run.