### PR TITLE
Fix komorebi not properly launching applications

### DIFF
--- a/src/OnScreen/Icon.vala
+++ b/src/OnScreen/Icon.vala
@@ -173,7 +173,10 @@ namespace Komorebi.OnScreen {
                         if(e.button == 1) {
 
                             // TODO: Replace event with 2BUTTON_PRESS
-                            AppInfo.launch_default_for_uri (@"file://$filePath", null);
+                            if(isExecutable)
+                                AppInfo.create_from_commandline(execPath, null, AppInfoCreateFlags.NONE).launch(null, null);
+                            else
+                                AppInfo.launch_default_for_uri (@"file://$filePath", null);
 
                         } else if(e.button == 3) { // Show the menu
                             BackgroundWindow backgroundWindow = parent.window;


### PR DESCRIPTION
This should fix a long standing issue where komorebi doesn't distinguish `.desktop` files and asks the system to open them with the most appropriate tool _(and since these are text files, it opened them with text editors)_.

Should fix https://github.com/cheesecakeufo/komorebi/issues/163 and fix https://github.com/cheesecakeufo/komorebi/issues/40 _(and probably more, couldn't find them all :stuck_out_tongue:)_