### PR TITLE
Remove code to change GNOME Shell's wallpaper

### DIFF
--- a/src/Utilities.vala
+++ b/src/Utilities.vala
@@ -373,11 +373,6 @@ namespace Komorebi.Utilities {
 
 		assetWidth = wallpaperKeyFile.get_integer ("Asset", "Width");
 		assetHeight = wallpaperKeyFile.get_integer ("Asset", "Height");
-
-		// Set GNOME's wallpaper to this
-		var wallpaperJpgPath = GLib.Path.build_filename(wallpaperPath, "wallpaper.jpg");
-		new GLib.Settings("org.gnome.desktop.background").set_string("picture-uri", ("file://" + wallpaperJpgPath));
-		new GLib.Settings("org.gnome.desktop.background").set_string("picture-options", "stretched");
 	}
 
 


### PR DESCRIPTION
This bit of code changes the current wallpaper of GNOME Shell to the same one as Komorebi. Not only I don't understand **why** it needs to do that *(I've tested this on many distros without any issue so far)*, this behaviour is also very confusing for users, as after closing and even uninstalling Komorebi, GNOME remains with a wallpaper Komorebi used.

Should fix https://github.com/cheesecakeufo/komorebi/issues/183, https://github.com/cheesecakeufo/komorebi/issues/153, https://github.com/cheesecakeufo/komorebi/issues/143, https://github.com/cheesecakeufo/komorebi/issues/109, https://github.com/cheesecakeufo/komorebi/issues/106, https://github.com/cheesecakeufo/komorebi/issues/187 *(and probably a lot more; it goes to show how many people had issues with it :confused: )*