### PR TITLE
Meson Build: change appdata.xml install location

### DIFF
--- a/data/Other/org.komorebiteam.komorebi.appdata.xml.in
+++ b/data/Other/org.komorebiteam.komorebi.appdata.xml.in
@@ -10,7 +10,7 @@
   <description>
     <p>
       Komorebi is an awesome animated wallpaper manager for all Linux platforms.
-      It provides fully customizeable image, video, and web page wallpapers that can be tweaked at any time!
+      It provides fully customisable image, video, and web page wallpapers that can be tweaked at any time!
     </p>
   </description>
 
@@ -27,7 +27,7 @@
   <project_group>Komorebi Team</project_group>
 
    <releases>
-    <release version="2.2.0" date="2020-07-xx">
+    <release version="2.2.0" date="2020-08-06">
       <description>
         <p>New Maintainers; Build system changed to Meson; Bugfixes.</p>
       </description>

--- a/data/Other/org.komorebiteam.wallpapercreator.appdata.xml.in
+++ b/data/Other/org.komorebiteam.wallpapercreator.appdata.xml.in
@@ -27,7 +27,7 @@
   <project_group>Komorebi Team</project_group>
 
    <releases>
-    <release version="1.3.0" date="2020-07-xx">
+    <release version="2.2.0" date="2020-08-06">
       <description>
         <p>New Maintainers; Build system changed to Meson; Bugfixes.</p>
       </description>

--- a/data/meson.build
+++ b/data/meson.build
@@ -27,7 +27,7 @@ foreach appdata_xml: [ 'org.komorebiteam.komorebi.appdata.xml', 'org.komorebitea
     output: appdata_xml,
     po_dir: po_dir,
     install: true,
-    install_dir: get_option('datadir') / 'appdata'
+    install_dir: get_option('datadir') / 'metainfo'
   )
 endforeach
 


### PR DESCRIPTION
Install appdata.xml to metainfo instead of the legacy appdata directory.

Update appdata.xml to have release date; bump version of wallpaper creator.