### PR TITLE
Removed unnecessary sudo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ There is no `.rpm` package yet, jump to the [compiling section](#compiling); if 
 Install from the [AUR](https://aur.archlinux.org/packages/komorebi/):
 
 ```bash
-sudo yay -S komorebi
+yay -S komorebi
 ```
 
 or grab the required dependencies:


### PR DESCRIPTION
Yay should not be run as root, otherwise it outputs the following error:
```
 -> Avoid running yay as root/sudo.
refusing to install AUR packages as root, aborting
```

It will later ask for sudo privileges when actually installing the package.