### PR TITLE
Implemented RPM packaging + hosting

### DIFF
--- a/data/Other/org.komorebiteam.komorebi.desktop.in
+++ b/data/Other/org.komorebiteam.komorebi.desktop.in
@@ -7,5 +7,5 @@ Exec=@bindir@/@projectname@
 Terminal=false
 Type=Application
 StartupNotify=true
-Categories=GNOME;GTK;System;
+Categories=GNOME;GTK;Settings;DesktopSettings;
 X-GNOME-Autostart-enabled=true

--- a/data/Other/org.komorebiteam.wallpapercreator.desktop.in
+++ b/data/Other/org.komorebiteam.wallpapercreator.desktop.in
@@ -7,5 +7,5 @@ Exec=@bindir@/@projectname@-wallpaper-creator
 Terminal=false
 Type=Application
 StartupNotify=true
-Categories=GNOME;GTK;System;
+Categories=GNOME;GTK;Settings;DesktopSettings;
 X-GNOME-Autostart-enabled=false

--- a/komorebi.spec
+++ b/komorebi.spec
@@ -1,0 +1,57 @@
+Name: komorebi
+Version: 2.2.0
+Release: 1%{?dist}
+Summary: A beautiful and customizable wallpaper manager for Linux 
+License: GPL-3.0
+
+URL: https://github.com/Komorebi-Fork/komorebi
+Source0: %{name}-%{version}.tar.xz
+
+BuildRequires: meson
+BuildRequires: vala
+BuildRequires: gcc
+BuildRequires: pkgconfig(glib-2.0)
+BuildRequires: pkgconfig(gobject-2.0)
+BuildRequires: pkgconfig(gtk+-3.0)
+BuildRequires: pkgconfig(gee-0.8)
+BuildRequires: pkgconfig(webkit2gtk-4.0)
+BuildRequires: pkgconfig(clutter-gtk-1.0)
+BuildRequires: pkgconfig(clutter-1.0)
+BuildRequires: pkgconfig(clutter-gst-3.0)
+
+%description
+Komorebi is an awesome animated wallpaper manager for all Linux platforms. It provides fully customizeable image, video, and web page wallpapers that can be tweaked at any time!
+
+%prep
+%autosetup
+
+%build
+%meson
+%meson_build
+
+%install
+%meson_install
+
+%check
+%meson_test
+
+%files
+/usr/bin/komorebi
+/usr/bin/komorebi-wallpaper-creator
+/usr/share/applications/org.komorebiteam.komorebi.desktop
+/usr/share/applications/org.komorebiteam.wallpapercreator.desktop
+/usr/share/fonts/AmaticSC-Regular.ttf
+/usr/share/fonts/Bangers-Regular.ttf
+/usr/share/fonts/BubblerOne-Regular.ttf
+/usr/share/fonts/Lato-Hairline.ttf
+/usr/share/fonts/Lato-Light.ttf
+/usr/share/fonts/VT323-Regular.ttf
+/usr/share/komorebi
+/usr/share/metainfo/org.komorebiteam.komorebi.appdata.xml
+/usr/share/metainfo/org.komorebiteam.wallpapercreator.appdata.xml
+/usr/share/pixmaps/komorebi
+
+%changelog
+* Sun Aug 30 2020 meson <meson@example.com> - 
+- 
+


### PR DESCRIPTION
- Added specification for RPM package building
- Replaced System category with Settings/DesktopSettings to meet RPM requirements (as described in here: https://en.opensuse.org/openSUSE:Packaging_desktop_menu_categories#SUSE_categories_enforcement) and more accurately reflect what this software does

I've also gone ahead to host RPM packages of the current version 2.2.0 on OBS for Fedora (stable+rawhide) aswell as OpenSUSE (leap+tumbleweed): https://build.opensuse.org/package/show/home:NNowakowski/Komorebi-Fork