### PR TITLE
Fix bug with window not being centered

### DIFF
--- a/src/OnScreen/BackgroundWindow.vala
+++ b/src/OnScreen/BackgroundWindow.vala
@@ -188,6 +188,7 @@ namespace Komorebi.OnScreen {
 			screenHeight = rectangle.height;
 			screenWidth = rectangle.width;
 
+			set_gravity(Gravity.STATIC);
 			move(rectangle.x, rectangle.y);
 
 		}


### PR DESCRIPTION
Fixes a bug with Elementary OS *(thus Pantheon DE)* users, where the desktop screen would display "off-centered" (https://github.com/cheesecakeufo/komorebi/issues/235 and https://github.com/cheesecakeufo/komorebi/issues/236). I guess the DE is doing something weird :stuck_out_tongue: 