### PR TITLE
Update Travis-CI Configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 language: c
 compiler: gcc
-sudo: required
+os: linux
 dist: bionic
+git:
+  depth: 1
 cache:
   - apt
+addons:
+  apt:
+    update: true
 before_install:
-  - sudo add-apt-repository ppa:gnome3-team/gnome3 -y
-  - sudo add-apt-repository ppa:vala-team -y
-  - sudo add-apt-repository ppa:gnome3-team/gnome3-staging -y
-  - sudo apt update
   - sudo apt install -y valac libgtk-3-dev libgee-0.8-dev libclutter-gtk-1.0-dev libclutter-1.0-dev libclutter-gst-3.0-dev libwebkit2gtk-4.0-dev python3 python3-pip python3-setuptools python3-wheel ninja-build
   - pip3 install --user meson
 


### PR DESCRIPTION
 - Git clone now shallow (no need to waste bandwidth).
 - Remove obsolete PPAs (not needed for bionic),
 - Have apt update be performed as part of travis init, rather than before install.
 - Remove obsolete 'sudo' key.
 - Add mising 'os' key.