### PR TITLE
Fix program crashing because it tries to process a NoneType

### DIFF
--- a/komorebi/overlays/desktop.py
+++ b/komorebi/overlays/desktop.py
@@ -159,7 +159,8 @@ class Icon(Clutter.Actor):
         self.drag_action = Clutter.DragAction()
 
         # Setup widgets
-        self.icon_image.set_data(pixbuf.get_pixels(),
+        if pixbuf != None:
+            self.icon_image.set_data(pixbuf.get_pixels(),
                                  Cogl.PixelFormat.RGBA_8888 if pixbuf.get_has_alpha() else Cogl.PixelFormat.RGB_888,
                                  icon_size, icon_size, pixbuf.get_rowstride())
         self.title_text.set_markup(f"<span color='white' font='Lato Bold 11'>{self.title_name}</span>")


### PR DESCRIPTION
Fixes:
```
Traceback (most recent call last):
  File "/usr/local/bin/komorebi", line 160, in <module>
    main()
  File "/usr/local/bin/komorebi", line 150, in main
    screen.load_wallpaper(Settings.wallpaper_name)
  File "/usr/local/lib/python3.12/site-packages/komorebi/screen.py", line 162, in load_wallpaper
    overlays = komorebi.utilities.load_overlays(self, wallpaper_info)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/komorebi/utilities.py", line 131, in load_overlays
    overlays.append(Desktop(screen))
                    ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/komorebi/overlays/desktop.py", line 497, in __init__
    self.get_desktops()
  File "/usr/local/lib/python3.12/site-packages/komorebi/overlays/desktop.py", line 638, in get_desktops
    self.grab_desktop_paths()
  File "/usr/local/lib/python3.12/site-packages/komorebi/overlays/desktop.py", line 681, in grab_desktop_paths
    icon = ApplicationIcon(name, icon_pixbuf, desktop_file.get_path(), command, self.icon_size)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/komorebi/overlays/desktop.py", line 285, in __init__
    Icon.__init__(self, name, pixbuf, icon_size)
  File "/usr/local/lib/python3.12/site-packages/komorebi/overlays/desktop.py", line 163, in __init__
    self.icon_image.set_data(pixbuf.get_pixels(),
                             ^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get_pixels'
```

feel free to find a better solution